### PR TITLE
Mantis #271 : add HttpOnly attribute

### DIFF
--- a/esigate-app-aggregated1/pom.xml
+++ b/esigate-app-aggregated1/pom.xml
@@ -34,7 +34,8 @@
 	<dependencies>
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
+			<artifactId>javax.servlet-api</artifactId>
+            <version>3.0.1</version>
 		</dependency>
 	</dependencies>
 </project> 

--- a/esigate-app-aggregated1/src/main/webapp/WEB-INF/web.xml
+++ b/esigate-app-aggregated1/src/main/webapp/WEB-INF/web.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
 <web-app id="aggregated1">
 	<display-name>aggregated1</display-name>
 	<servlet>

--- a/esigate-app-aggregated1/src/main/webapp/cookies.jsp
+++ b/esigate-app-aggregated1/src/main/webapp/cookies.jsp
@@ -1,7 +1,9 @@
 <%@page import="java.util.Enumeration"%>
 <%@page contentType="text/html; charset=UTF-8"%>
 <%
-	response.addCookie(new Cookie("test0", "value0"));
+    Cookie cookie = new Cookie("test0", "value0");
+    cookie.setHttpOnly(true);
+	response.addCookie(cookie);
 %>
 <%
 	response.addCookie(new Cookie("test1", "value1"));

--- a/esigate-app-aggregator/pom.xml
+++ b/esigate-app-aggregator/pom.xml
@@ -38,7 +38,7 @@
 			<artifactId>junit-addons</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>httpunit</groupId>
+			<groupId>org.httpunit</groupId>
 			<artifactId>httpunit</artifactId>
 		</dependency>
 		<dependency>
@@ -132,8 +132,8 @@
 				</executions>
 				<configuration>
 					<container>
-						<containerId>jetty7x</containerId>
-						<type>embedded</type>
+						<containerId>jetty8x</containerId>
+                        <type>embedded</type>
 					</container>
 					<deployables>
 						<deployable>

--- a/esigate-app-aggregator/src/test/java/org/esigate/test/cases/AggregatorTest.java
+++ b/esigate-app-aggregator/src/test/java/org/esigate/test/cases/AggregatorTest.java
@@ -31,10 +31,22 @@ public class AggregatorTest extends TestCase {
     private void doCookieSimpleTest(String page, String resultResource) throws Exception {
         WebRequest req = new GetMethodWebRequest(APPLICATION_PATH + page);
         WebResponse resp = webConversation.getResponse(req);
+
         assertEquals("Status should be 200", HttpServletResponse.SC_OK, resp.getResponseCode());
         assertEquals(getResource(resultResource).replaceAll("\r", "").replaceAll("\n", "").replaceAll("\t", "")
                 .replaceAll(" ", "").replaceAll("JSESSIONID=[^;]+;", ""), resp.getText().replaceAll("\r", "")
                 .replaceAll("\n", "").replaceAll("\t", "").replaceAll(" ", "").replaceAll("JSESSIONID=[^;]+;", ""));
+
+        String[] setcookies = resp.getHeaderFields("Set-Cookie");
+        boolean containsHttpOnlyCookie = false;
+        for (int i = 0; i < setcookies.length; i++) {
+            if (setcookies[i].toString().contains("test0")) {
+                assertTrue(setcookies[i].contains("HttpOnly"));
+                containsHttpOnlyCookie = true;
+            }
+        }
+        assertTrue("Response should contains an HttpOnly cookie test0", containsHttpOnlyCookie);
+
     }
 
     private void doSimpleTest(String page) throws Exception {
@@ -112,6 +124,7 @@ public class AggregatorTest extends TestCase {
     public void testCookies() throws Exception {
         doCookieSimpleTest("nocache/ag1/cookies.jsp", "cookies-firstcall.html");
         doCookieSimpleTest("nocache/ag1/cookies.jsp", "cookies.html");
+        webConversation.getCookieDetails("test0");
     }
 
     /**

--- a/esigate-app-casified-aggregator/pom.xml
+++ b/esigate-app-casified-aggregator/pom.xml
@@ -53,7 +53,7 @@
 			<artifactId>junit-addons</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>httpunit</groupId>
+			<groupId>org.httpunit</groupId>
 			<artifactId>httpunit</artifactId>
 		</dependency>
 		<dependency>

--- a/esigate-app-master/pom.xml
+++ b/esigate-app-master/pom.xml
@@ -28,7 +28,7 @@
 			<artifactId>junit-addons</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>httpunit</groupId>
+			<groupId>org.httpunit</groupId>
 			<artifactId>httpunit</artifactId>
 		</dependency>
 		<dependency>

--- a/esigate-core/src/main/java/org/esigate/cookie/DefaultCookieManager.java
+++ b/esigate-core/src/main/java/org/esigate/cookie/DefaultCookieManager.java
@@ -28,6 +28,7 @@ import org.esigate.ConfigurationException;
 import org.esigate.Driver;
 import org.esigate.Parameters;
 import org.esigate.UserContext;
+import org.esigate.http.cookie.CookieUtil;
 import org.esigate.impl.DriverRequest;
 import org.esigate.util.UriUtils;
 import org.slf4j.Logger;
@@ -179,7 +180,7 @@ public class DefaultCookieManager implements CookieManager {
         return domain;
     }
 
-    private static Cookie rewriteForBrowser(Cookie cookie, DriverRequest request) {
+    protected static Cookie rewriteForBrowser(Cookie cookie, DriverRequest request) {
         String name = cookie.getName();
         // Rewrite name if JSESSIONID because it will interfere with current
         // server session
@@ -212,6 +213,10 @@ public class DefaultCookieManager implements CookieManager {
         cookieToForward.setComment(cookie.getComment());
         cookieToForward.setVersion(cookie.getVersion());
         cookieToForward.setExpiryDate(cookie.getExpiryDate());
+
+        if (((BasicClientCookie) cookie).containsAttribute(CookieUtil.HTTP_ONLY_ATTR)) {
+            cookieToForward.setAttribute(CookieUtil.HTTP_ONLY_ATTR, "");
+        }
 
         if (LOG.isDebugEnabled()) {
             // Ensure .toString is only called if debug enabled.

--- a/esigate-core/src/main/java/org/esigate/http/cookie/CookieUtil.java
+++ b/esigate-core/src/main/java/org/esigate/http/cookie/CookieUtil.java
@@ -1,9 +1,71 @@
 package org.esigate.http.cookie;
 
+import java.net.HttpCookie;
+
+import org.apache.http.cookie.Cookie;
+import org.apache.http.impl.cookie.BasicClientCookie;
+import org.apache.http.impl.cookie.BrowserCompatSpec;
+
 /**
  * @author Alexis Thaveau on 20/10/14.
  */
 public class CookieUtil {
 
     public static String HTTP_ONLY_ATTR = "httponly";
+
+    public static String encodeCookie(Cookie cookie) {
+        int maxAge = -1;
+        if (cookie.getExpiryDate() != null) {
+            maxAge = (int) ((cookie.getExpiryDate().getTime() - System.currentTimeMillis()) / 1000);
+            // According to Cookie class specification, a negative value
+            // would be considered as no value. That is not what we want!
+            if (maxAge < 0) {
+                maxAge = 0;
+            }
+        }
+
+        StringBuffer buf = new StringBuffer(cookie.getName());
+        buf.append("=");
+        buf.append(cookie.getValue());
+
+        if (cookie.getComment() != null) {
+            buf.append("; Comment=\"");
+            buf.append(cookie.getComment());
+            buf.append("\"");
+        }
+
+        if (cookie.getDomain() != null) {
+            buf.append("; Domain=\"");
+            buf.append(cookie.getDomain());
+            buf.append("\"");
+        }
+
+        if (maxAge >= 0) {
+            buf.append("; Max-Age=\"");
+            buf.append(maxAge);
+            buf.append("\"");
+        }
+
+        if (cookie.getPath() != null) {
+            buf.append("; Path=\"");
+            buf.append(cookie.getPath());
+            buf.append("\"");
+        }
+
+        if (cookie.isSecure()) {
+            buf.append("; Secure");
+        }
+        if (((BasicClientCookie) cookie).containsAttribute(HTTP_ONLY_ATTR)) {
+            buf.append("; HttpOnly");
+        }
+
+        if (cookie.getVersion() > 0) {
+            buf.append("; Version=\"");
+            buf.append(cookie.getVersion());
+            buf.append("\"");
+        }
+
+        return (buf.toString());
+    }
+
 }

--- a/esigate-core/src/main/java/org/esigate/http/cookie/CustomBrowserCompatSpecFactory.java
+++ b/esigate-core/src/main/java/org/esigate/http/cookie/CustomBrowserCompatSpecFactory.java
@@ -1,7 +1,38 @@
 package org.esigate.http.cookie;
 
+import org.apache.http.annotation.Immutable;
+import org.apache.http.cookie.CookieSpec;
+import org.apache.http.impl.cookie.AbstractCookieSpec;
+import org.apache.http.impl.cookie.BrowserCompatSpecFactory;
+import org.apache.http.params.HttpParams;
+import org.apache.http.protocol.HttpContext;
+
 /**
+ * A BrowserCompatSpecFactory that register HttpOnly handler
+ * 
  * @author Alexis Thaveau on 21/10/14.
  */
-public class CustomBrowserCompatSpecFactory {
+@Immutable
+@SuppressWarnings("deprecation")
+public class CustomBrowserCompatSpecFactory extends BrowserCompatSpecFactory {
+
+    /**
+     *
+     */
+    public final static String CUSTOM_BROWSER_COMPATIBILITY = "custom_browser_compatibility";
+
+    @Override
+    public CookieSpec newInstance(final HttpParams params) {
+        AbstractCookieSpec cookieSpec = (AbstractCookieSpec) super.newInstance(params);
+        cookieSpec.registerAttribHandler(CookieUtil.HTTP_ONLY_ATTR, new HttpOnlyHandler());
+        return cookieSpec;
+    }
+
+    @Override
+    public CookieSpec create(final HttpContext context) {
+        AbstractCookieSpec cookieSpec = (AbstractCookieSpec) super.create(context);
+        cookieSpec.registerAttribHandler(CookieUtil.HTTP_ONLY_ATTR, new HttpOnlyHandler());
+        return cookieSpec;
+    }
+
 }

--- a/esigate-core/src/main/java/org/esigate/http/cookie/HttpOnlyHandler.java
+++ b/esigate-core/src/main/java/org/esigate/http/cookie/HttpOnlyHandler.java
@@ -1,7 +1,29 @@
 package org.esigate.http.cookie;
 
+import org.apache.http.annotation.Immutable;
+import org.apache.http.cookie.MalformedCookieException;
+import org.apache.http.cookie.SetCookie;
+import org.apache.http.impl.cookie.AbstractCookieAttributeHandler;
+import org.apache.http.impl.cookie.BasicClientCookie;
+import org.apache.http.util.Args;
+
 /**
+ * Handler for HttpOnly attribute
+ * 
  * @author Alexis Thaveau on 20/10/14.
  */
-public class HttpOnlyHandler {
+@Immutable
+public class HttpOnlyHandler extends AbstractCookieAttributeHandler {
+
+    public HttpOnlyHandler() {
+        super();
+    }
+
+    public void parse(final SetCookie cookie, final String value) throws MalformedCookieException {
+
+        Args.notNull(cookie, "Cookie");
+        ((BasicClientCookie) cookie).setAttribute(CookieUtil.HTTP_ONLY_ATTR, "");
+
+    }
+
 }

--- a/esigate-core/src/test/java/org/esigate/http/cookie/CookieUtilTest.java
+++ b/esigate-core/src/test/java/org/esigate/http/cookie/CookieUtilTest.java
@@ -1,7 +1,75 @@
 package org.esigate.http.cookie;
 
+import java.net.HttpCookie;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import org.apache.http.Header;
+import org.apache.http.client.utils.DateUtils;
+import org.apache.http.cookie.Cookie;
+import org.apache.http.cookie.CookieOrigin;
+import org.apache.http.cookie.CookieSpec;
+import org.apache.http.message.BasicHeader;
+
 import junit.framework.TestCase;
 
 public class CookieUtilTest extends TestCase {
 
+    private SimpleDateFormat format;
+    CookieSpec cookieSpec;
+
+    @Override
+    protected void setUp() throws Exception {
+
+        format = new SimpleDateFormat(DateUtils.PATTERN_RFC1123, Locale.US);
+        format.setTimeZone(TimeZone.getTimeZone("GMT"));
+        cookieSpec = new CustomBrowserCompatSpecFactory().newInstance(null);
+        super.setUp();
+    }
+
+    public void testHttpOnlyCookie() throws Exception {
+
+        String expires = format.format(new Date(System.currentTimeMillis() + 86400000));
+        Header header =
+                new BasicHeader("Set-Cookie", "K_lm_66638=121203111217326896; Domain=.foo.com; Expires=" + expires
+                        + "; HttpOnly;Secure;Path=/");
+        CookieOrigin origin = new CookieOrigin("www.foo.com", 80, "/", false);
+        Cookie src = cookieSpec.parse(header, origin).get(0);
+        String result = CookieUtil.encodeCookie(src);
+        HttpCookie httpcookie = HttpCookie.parse(result).get(0);
+        assertTrue("Should be an httponly cookie", httpcookie.isHttpOnly());
+        assertTrue("Should be a secure cookie", httpcookie.getSecure());
+    }
+
+    public void testRewriteCookieExpires() throws Exception {
+        String expires = format.format(new Date(System.currentTimeMillis() + 86400000));
+        Header header =
+                new BasicHeader("Set-Cookie", "K_lm_66638=121203111217326896; Domain=.foo.com; Expires=" + expires
+                        + "; Path=/");
+        CookieOrigin origin = new CookieOrigin("www.foo.com", 80, "/", false);
+        Cookie src = cookieSpec.parse(header, origin).get(0);
+        String result = CookieUtil.encodeCookie(src);
+        HttpCookie httpcookie = HttpCookie.parse(result).get(0);
+        assertTrue("maxAge should be greater than 86395, actual value " + httpcookie.getMaxAge(),
+                httpcookie.getMaxAge() > 86395);
+        assertTrue("maxAge should be lower than 86401, actual value " + httpcookie.getMaxAge(),
+                httpcookie.getMaxAge() < 86401);
+    }
+
+    public void testRewriteCookieExpiresLongTime() throws Exception {
+        String expires = format.format(new Date(System.currentTimeMillis() + 15552000000L));
+        Header header =
+                new BasicHeader("Set-Cookie", "K_66638=121203111217326896; Domain=.foo.com; Expires=" + expires
+                        + "; Path=/");
+        CookieOrigin origin = new CookieOrigin("www.foo.com", 80, "/", false);
+        Cookie src = cookieSpec.parse(header, origin).get(0);
+        String result = CookieUtil.encodeCookie(src);
+        HttpCookie httpcookie = HttpCookie.parse(result).get(0);
+        assertTrue("maxAge should be greater than 15551995, actual value " + httpcookie.getMaxAge(),
+                httpcookie.getMaxAge() > 15551995);
+        assertTrue("maxAge should be lower than 15552001, actual value " + httpcookie.getMaxAge(),
+                httpcookie.getMaxAge() < 15552001);
+    }
 }

--- a/esigate-server/pom.xml
+++ b/esigate-server/pom.xml
@@ -45,7 +45,7 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>httpunit</groupId>
+			<groupId>org.httpunit</groupId>
 			<artifactId>httpunit</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/esigate-servlet/src/main/java/org/esigate/servlet/impl/RequestFactory.java
+++ b/esigate-servlet/src/main/java/org/esigate/servlet/impl/RequestFactory.java
@@ -97,7 +97,9 @@ public class RequestFactory {
             builder.setSessionId(session.getId());
         }
         builder.setUserPrincipal(request.getUserPrincipal());
+
         // Copy cookies
+        // FIXME : As cookie header contains only name=value, why are we copying all attributes ?
         javax.servlet.http.Cookie[] src = request.getCookies();
         if (src != null) {
             for (int i = 0; i < src.length; i++) {

--- a/esigate-servlet/src/main/java/org/esigate/servlet/impl/ResponseSender.java
+++ b/esigate-servlet/src/main/java/org/esigate/servlet/impl/ResponseSender.java
@@ -24,36 +24,14 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.cookie.Cookie;
 import org.esigate.http.IncomingRequest;
+import org.esigate.http.cookie.CookieUtil;
 
 /**
  * Renders a response to the HttpSerlvetResponse.
  * 
  * @author Francois-Xavier Bonnet
- * 
  */
 public class ResponseSender {
-
-    public javax.servlet.http.Cookie rewriteCookie(Cookie src) {
-        javax.servlet.http.Cookie servletCookie = new javax.servlet.http.Cookie(src.getName(), src.getValue());
-
-        if (src.getDomain() != null) {
-            servletCookie.setDomain(src.getDomain());
-        }
-        servletCookie.setPath(src.getPath());
-        servletCookie.setSecure(src.isSecure());
-        servletCookie.setComment(src.getComment());
-        servletCookie.setVersion(src.getVersion());
-        if (src.getExpiryDate() != null) {
-            int maxAge = (int) ((src.getExpiryDate().getTime() - System.currentTimeMillis()) / 1000);
-            // According to Cookie class specification, a negative value
-            // would be considered as no value. That is not what we want!
-            if (maxAge < 0) {
-                maxAge = 0;
-            }
-            servletCookie.setMaxAge(maxAge);
-        }
-        return servletCookie;
-    }
 
     public void sendResponse(HttpResponse httpResponse, IncomingRequest httpRequest, HttpServletResponse response)
             throws IOException {
@@ -66,8 +44,9 @@ public class ResponseSender {
 
         // Copy new cookies
         Cookie[] newCookies = httpRequest.getNewCookies();
+
         for (int i = 0; i < newCookies.length; i++) {
-            response.addCookie(rewriteCookie(newCookies[i]));
+            response.addHeader("Set-Cookie", CookieUtil.encodeCookie(newCookies[i]));
         }
 
         HttpEntity httpEntity = httpResponse.getEntity();

--- a/pom.xml
+++ b/pom.xml
@@ -108,8 +108,8 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.1</version>
 					<configuration>
-						<source>1.6</source>
-						<target>1.6</target>
+						<source>1.7</source>
+						<target>1.7</target>
 						<encoding>UTF-8</encoding>
 					</configuration>
 				</plugin>
@@ -523,9 +523,9 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
-				<groupId>httpunit</groupId>
+				<groupId>org.httpunit</groupId>
 				<artifactId>httpunit</artifactId>
-				<version>1.6.2</version>
+				<version>1.7.2</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Please review this commit. There are lot of impact for only one additionnal attribute, and i had to upgrade httpunit, because 1.6 version doesn't manage HttpOnly Attribute. 

I have updated existing unit test case, i hope i didn't missing anything
