### PR TITLE
Removed DTD : internet access was required to start esigate

### DIFF
--- a/esigate-war/src/main/webapp/WEB-INF/web.xml
+++ b/esigate-war/src/main/webapp/WEB-INF/web.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
 <web-app>
 	<filter>
 		<filter-name>EsiGate</filter-name>


### PR DESCRIPTION
The DTD seems to require a hit to oracle.com. 
If the server does not have access to the internet, startup will fail.
