### PR TITLE
JQuery selector interpreted like a ESIgate variable during an

### DIFF
--- a/esigate-core/src/main/java/org/esigate/extension/parallelesi/ReplaceElement.java
+++ b/esigate-core/src/main/java/org/esigate/extension/parallelesi/ReplaceElement.java
@@ -25,7 +25,6 @@ import org.esigate.parser.future.CharSequenceFuture;
 import org.esigate.parser.future.FutureElementType;
 import org.esigate.parser.future.FutureParserContext;
 import org.esigate.parser.future.StringBuilderFutureAppendable;
-import org.esigate.vars.VariablesResolver;
 
 /**
  * Support for &lt;esi:replace&gt; element inside of parent &lt;esi:include&gt;


### PR DESCRIPTION
esi:include
Fixed warning
https://github.com/esigate/esigate/issues/35
