### PR TITLE
Fixed build error:

### DIFF
--- a/esigate-app-casified-aggregated2/pom.xml
+++ b/esigate-app-casified-aggregated2/pom.xml
@@ -38,6 +38,12 @@
 			<artifactId>spring-security-cas</artifactId>
 			<version>4.0.0.RELEASE</version>
 			<scope>compile</scope>
+			<exclusions>
+				<exclusion>
+					<artifactId>log4j-over-slf4j</artifactId>
+					<groupId>org.slf4j</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.security</groupId>


### PR DESCRIPTION
Caused by:
java.lang.IllegalStateException: Detected both log4j-over-slf4j.jar AND
slf4j-log4j12.jar on the class path, preempting StackOverflowError. See
also http://www.slf4j.org/codes.html#log4jDelegationLoop for more
details.