### PR TITLE
java.lang.IllegalArgumentException: Illegal character with urls that contain html entities

### DIFF
--- a/esigate-core/src/main/java/org/esigate/util/UriUtils.java
+++ b/esigate-core/src/main/java/org/esigate/util/UriUtils.java
@@ -188,13 +188,9 @@ public final class UriUtils {
         uri = encodeIllegalCharacters(uri);
         URI result = URI.create(uri);
         if (result.getHost() != null && StringUtils.isEmpty(result.getPath())) {
-            try {
-                result =
-                        new URI(result.getScheme(), result.getRawUserInfo(), result.getHost(), result.getPort(), "/",
-                                result.getRawQuery(), result.getRawFragment());
-            } catch (URISyntaxException e) {
-                throw new InvalidUriException(e);
-            }
+            result =
+                    URI.create(createURI(result.getScheme(), result.getHost(), result.getPort(), "/",
+                            result.getRawQuery(), result.getRawFragment()));
         }
         return result;
     }

--- a/esigate-core/src/test/java/org/esigate/impl/UrlRewriterTest.java
+++ b/esigate-core/src/test/java/org/esigate/impl/UrlRewriterTest.java
@@ -457,4 +457,26 @@ public class UrlRewriterTest extends TestCase {
         assertDoesNotRewrite("mailto:test@test.com");
     }
 
+    public void testHtmlUnicodeEntities() {
+        baseUrl = "http://backend";
+        visibleUrlBase = "http://visible/context/";
+        requestUrl = "/";
+        absolute = true;
+
+        String html = "<a href='http://backend?param=I&#39;am&param2=I&#39;am'>";
+        String rewrittenHtml = "<a href='http://visible/context/?param=I&apos;am&amp;param2=I&apos;am'>";
+        assertRewritesHtml(html, rewrittenHtml);
+    }
+
+    public void testHtmlRewriteUrlWithEncodedCharacters() {
+        baseUrl = "http://backend";
+        visibleUrlBase = "http://visible/context/";
+        requestUrl = "/";
+        absolute = true;
+
+        String html = "<a href='http://backend?test=%20'>";
+        String rewrittenHtml = "<a href='http://visible/context/?test=%20'>";
+        assertRewritesHtml(html, rewrittenHtml);
+    }
+
 }

--- a/esigate-core/src/test/java/org/esigate/util/UriUtilsTest.java
+++ b/esigate-core/src/test/java/org/esigate/util/UriUtilsTest.java
@@ -157,4 +157,12 @@ public class UriUtilsTest extends TestCase {
         assertEquals("test", uri.getPath());
     }
 
+    public void testCreateUriAddsSlashIfNoPath() {
+        assertParses("http://foo.com?q=1", "http://foo.com/?q=1");
+    }
+
+    public void testCreateUriNoPathAndUrlEncodedCharacters() {
+        assertParses("http://foo.com?q=%20", "http://foo.com/?q=%20");
+    }
+
 }


### PR DESCRIPTION
https://github.com/esigate/esigate/issues/125

Html entities are now escaped/unescaped using
org.apache.commons.lang3.StringEscapeUtils