### PR TITLE
Consumes http entity on redirection

### DIFF
--- a/esigate-core/src/main/java/org/esigate/Driver.java
+++ b/esigate-core/src/main/java/org/esigate/Driver.java
@@ -178,6 +178,7 @@ public final class Driver {
             try {
                 while (redirects > 0
                         && redirectStrategy.isRedirected(outgoingRequest, response, outgoingRequest.getContext())) {
+                    HttpResponseUtils.toString(response);
                     redirects--;
                     outgoingRequest =
                             requestExecutor.createOutgoingRequest(

--- a/esigate-core/src/test/java/org/esigate/DriverTest.java
+++ b/esigate-core/src/test/java/org/esigate/DriverTest.java
@@ -14,14 +14,12 @@
 
 package org.esigate;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
+import java.io.*;
 import java.net.SocketTimeoutException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.zip.GZIPOutputStream;
 
 import junit.framework.Assert;


### PR DESCRIPTION
The esigate driver did not consume http entity on redirection
This happens when the http response is a stream entity.
