### PR TITLE
Handle UnknowProvider

### DIFF
--- a/esigate-core/src/main/java/org/esigate/esi/IncludeElement.java
+++ b/esigate-core/src/main/java/org/esigate/esi/IncludeElement.java
@@ -24,6 +24,7 @@ import java.util.Map.Entry;
 import java.util.regex.Pattern;
 
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.esigate.ConfigurationException;
 import org.esigate.Driver;
 import org.esigate.DriverFactory;
 import org.esigate.HttpErrorPage;
@@ -81,6 +82,10 @@ class IncludeElement extends BaseElement {
             processPage(src, includeTag, ctx);
         } catch (IOException | HttpErrorPage e) {
             currentException = e;
+        } catch (ConfigurationException e) {
+            // case uknown provider : log error
+            currentException = e;
+            LOG.error("Esi Include Tag with unknown Provider :" + e.getMessage());
         }
 
         // Handle Alt
@@ -91,6 +96,10 @@ class IncludeElement extends BaseElement {
                 processPage(alt, includeTag, ctx);
             } catch (IOException | HttpErrorPage e) {
                 currentException = e;
+            } catch (ConfigurationException e) {
+                // case uknown provider : log error
+                currentException = e;
+                LOG.error("Esi Include Tag with unknown Provider :" + e.getMessage());
             }
         }
 
@@ -100,9 +109,11 @@ class IncludeElement extends BaseElement {
                 throw (IOException) currentException;
             } else if (currentException instanceof HttpErrorPage) {
                 throw (HttpErrorPage) currentException;
+            } else if (currentException instanceof ConfigurationException) {
+                throw (ConfigurationException) currentException;
             }
             throw new IllegalStateException(
-                    "This type of exception is unexpected here. Should be IOException or HttpErrorPageException.",
+                    "This type of exception is unexpected here. Should be IOException or HttpErrorPageException or ConfigurationException.",
                     currentException);
 
         }

--- a/esigate-core/src/test/java/org/esigate/esi/IncludeElementTest.java
+++ b/esigate-core/src/test/java/org/esigate/esi/IncludeElementTest.java
@@ -19,6 +19,7 @@ import java.util.Date;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.impl.cookie.BasicClientCookie;
+import org.esigate.ConfigurationException;
 import org.esigate.HttpErrorPage;
 
 public class IncludeElementTest extends AbstractElementTest {
@@ -338,5 +339,47 @@ public class IncludeElementTest extends AbstractElementTest {
         result = render(page);
         expected = "code fragment";
         assertEquals(expected, result);
+    }
+
+    public void testIncludeProviderWithUnknownProvider() throws IOException, HttpErrorPage {
+
+        // Test unknownProvider => error
+        try {
+            String page = "Before <esi:include src=\"$(PROVIDER{unknown})/test\" /> After";
+            render(page);
+            fail("Should have ConfigurationException");
+        } catch (ConfigurationException e) {
+            assertEquals("No configuration properties found for factory : unknown", e.getMessage());
+        }
+
+        // Test unknownProvider => with onerror="continue
+        String page = "Before <esi:include src=\"$(PROVIDER{unknown})/test\" onerror=\"continue\"/> After";
+        String result = render(page);
+        String expected = "Before  After";
+        assertEquals(expected, result);
+
+        // Test unknownProvider => with alt
+        page = "Before <esi:include src=\"$(PROVIDER{unknown})/test\" alt=\"http://www.foo.com/test\" /> After";
+        result = render(page);
+        expected = "Before test After";
+        assertEquals(expected, result);
+
+        // Test unknownProvider => with alt with unknowProvider
+        try {
+            page = "Before <esi:include src=\"$(PROVIDER{unknown})/test\" alt=\"$(PROVIDER{unknown2})/test2\" /> After";
+            render(page);
+            fail("Should have ConfigurationException");
+        } catch (ConfigurationException e) {
+            assertEquals("No configuration properties found for factory : unknown2", e.getMessage());
+        }
+
+        // Test unknownProvider => with alt with unknowProvider an
+        // onerror=continue
+        page =
+                "Before <esi:include src=\"$(PROVIDER{unknown})/test\" alt=\"$(PROVIDER{unknown2})/test2\" onerror=\"continue\"/> After";
+        result = render(page);
+        expected = "Before  After";
+        assertEquals(expected, result);
+
     }
 }


### PR DESCRIPTION
IncludeElement Change with testUnit:

When a unknow provider is used in include tag, the error may be handled with try/except tag or onerror and alt.
The error is always log in ERROR Level : 
"Esi Include Tag with unknown Provider : No configuration properties found for factory : UnknowProviderName" where UnknownProviderName is the name of the provider in include tag


I guess you want LOG ERROR only for ConfigurationException.
Log is always done even if onerror is not continue
Log is not tested with junit

I don't know enough esigate to understand "parallelesi", I report stupidly my changes on it.

I don't test my modification with your integration test application.
