### PR TITLE
Redirect handling for fragments is using the public host …

### DIFF
--- a/esigate-core/src/main/java/org/esigate/Driver.java
+++ b/esigate-core/src/main/java/org/esigate/Driver.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Properties;
 
 import org.apache.commons.io.output.StringBuilderWriter;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.HttpEntity;
@@ -48,6 +49,7 @@ import org.esigate.http.OutgoingRequest;
 import org.esigate.http.ResourceUtils;
 import org.esigate.impl.DriverRequest;
 import org.esigate.impl.UrlRewriter;
+import org.esigate.util.UriUtils;
 import org.esigate.vars.VariablesResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -100,6 +102,7 @@ public final class Driver {
                             .setProperties(properties).setContentTypeHelper(driver.contentTypeHelper).build();
             driver.urlRewriter = urlRewriter;
             driver.headerManager = new HeaderManager(urlRewriter);
+
             return driver;
         }
 
@@ -170,6 +173,7 @@ public final class Driver {
 
         String cacheKey = CACHE_RESPONSE_PREFIX + targetUrl;
         Pair<String, CloseableHttpResponse> cachedValue = incomingRequest.getAttribute(cacheKey);
+
         // content and response were not in cache
         if (cachedValue == null) {
             OutgoingRequest outgoingRequest = requestExecutor.createOutgoingRequest(driverRequest, targetUrl, false);
@@ -178,24 +182,32 @@ public final class Driver {
             int redirects = MAX_REDIRECTS;
             try {
                 while (redirects > 0
-                        && redirectStrategy.isRedirected(outgoingRequest, response, outgoingRequest.getContext())) {
+                        && this.redirectStrategy.isRedirected(outgoingRequest, response, outgoingRequest.getContext())) {
 
                     // Must consume the entity
                     EntityUtils.consumeQuietly(response.getEntity());
 
                     redirects--;
-                    outgoingRequest =
-                            requestExecutor.createOutgoingRequest(
-                                    driverRequest,
-                                    redirectStrategy.getLocationURI(outgoingRequest, response,
-                                            outgoingRequest.getContext()).toString(), false);
-                    headerManager.copyHeaders(driverRequest, outgoingRequest);
+
+                    // Pick the location header. 
+                    resultingPageUrl = 
+                            this.redirectStrategy.getLocationURI(outgoingRequest, response, outgoingRequest.getContext())
+                                    .toString();
+                    // Remove context if present
+                    if( StringUtils.startsWith(resultingPageUrl, driverRequest.getVisibleBaseUrl())){
+                        resultingPageUrl = "/"+StringUtils.stripStart(StringUtils.replace(resultingPageUrl, driverRequest.getVisibleBaseUrl(), ""), "/");
+                    }
+                    targetUrl = ResourceUtils.getHttpUrlWithQueryString(resultingPageUrl, driverRequest, false);
+
+                    // Perform new request
+                    outgoingRequest = this.requestExecutor.createOutgoingRequest(driverRequest, targetUrl, false);
+                    this.headerManager.copyHeaders(driverRequest, outgoingRequest);
                     response = requestExecutor.execute(outgoingRequest);
                 }
             } catch (ProtocolException e) {
                 throw new HttpErrorPage(HttpStatus.SC_BAD_GATEWAY, "Invalid response from server", e);
             }
-            response = headerManager.copyHeaders(outgoingRequest, incomingRequest, response);
+            response = this.headerManager.copyHeaders(outgoingRequest, incomingRequest, response);
             currentValue = HttpResponseUtils.toString(response, this.eventManager);
             // Cache
             cachedValue = new ImmutablePair<>(currentValue, response);

--- a/esigate-core/src/main/java/org/esigate/api/RedirectStrategy2.java
+++ b/esigate-core/src/main/java/org/esigate/api/RedirectStrategy2.java
@@ -1,0 +1,26 @@
+package org.esigate.api;
+
+import java.net.URI;
+
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.ProtocolException;
+import org.apache.http.client.RedirectStrategy;
+import org.apache.http.protocol.HttpContext;
+
+/**
+ * Interface for redirect strategies used by driver when retrieving content from providers.
+ * 
+ * <p>
+ * This interface is based on {@link RedirectStrategy} and expose one additional method :
+ * 
+ * @see RedirectStrategy2#getLocationURI(HttpRequest, HttpResponse, HttpContext)
+ * 
+ * @author Nicolas Richeton
+ * 
+ */
+public interface RedirectStrategy2 extends RedirectStrategy {
+
+    URI getLocationURI(final HttpRequest request, final HttpResponse response, final HttpContext context)
+            throws ProtocolException;
+}

--- a/esigate-core/src/main/java/org/esigate/impl/FragmentRedirectStrategy.java
+++ b/esigate-core/src/main/java/org/esigate/impl/FragmentRedirectStrategy.java
@@ -1,0 +1,98 @@
+package org.esigate.impl;
+
+import java.net.URI;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.ProtocolException;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.impl.client.DefaultRedirectStrategy;
+import org.apache.http.protocol.HttpContext;
+import org.esigate.api.RedirectStrategy2;
+import org.esigate.http.OutgoingRequest;
+import org.esigate.http.ResourceUtils;
+import org.esigate.util.UriUtils;
+
+/**
+ * The redirect strategy for fetching fragments.
+ * 
+ * <p>
+ * This strategy is based on {@link DefaultRedirectStrategy} but differs for local redirections:
+ * 
+ * <p>
+ * If a local (same provider) redirection is detected, the URI is returned as relative. This ensure that a public
+ * (visible) url is not used instead of the provider url for the next requests.
+ * 
+ * @author Nicolas Richeton
+ * 
+ */
+public class FragmentRedirectStrategy implements RedirectStrategy2 {
+    private final DefaultRedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
+
+    /**
+     * @see DefaultRedirectStrategy#isRedirected(HttpRequest, HttpResponse, HttpContext)
+     */
+    @Override
+    public boolean isRedirected(HttpRequest request, HttpResponse response, HttpContext context)
+            throws ProtocolException {
+        return this.redirectStrategy.isRedirected(request, response, context);
+    }
+
+    /**
+     * @see DefaultRedirectStrategy#getRedirect(HttpRequest, HttpResponse, HttpContext)
+     */
+    @Override
+    public HttpUriRequest getRedirect(HttpRequest request, HttpResponse response, HttpContext context)
+            throws ProtocolException {
+
+        // Code from DefaultRedirectStrategy
+        // To ensure usage of the local getLocationURI implementation.
+
+        final URI uri = getLocationURI(request, response, context);
+        final String method = request.getRequestLine().getMethod();
+        if (method.equalsIgnoreCase(HttpHead.METHOD_NAME)) {
+            return new HttpHead(uri);
+        } else if (method.equalsIgnoreCase(HttpGet.METHOD_NAME)) {
+            return new HttpGet(uri);
+        } else {
+            final int status = response.getStatusLine().getStatusCode();
+            if (status == HttpStatus.SC_TEMPORARY_REDIRECT) {
+                return RequestBuilder.copy(request).setUri(uri).build();
+            } else {
+                return new HttpGet(uri);
+            }
+        }
+    }
+
+    /**
+     * For local redirects, converts to relative urls.
+     * 
+     * @param request
+     *            must be an {@link OutgoingRequest}.
+     */
+    @Override
+    public URI getLocationURI(HttpRequest request, HttpResponse response, HttpContext context) throws ProtocolException {
+        URI uri = this.redirectStrategy.getLocationURI(request, response, context);
+
+        String resultingPageUrl = uri.toString();
+
+        DriverRequest driverRequest = ((OutgoingRequest) request).getOriginalRequest();
+
+        // Remove context if present
+        if (StringUtils.startsWith(resultingPageUrl, driverRequest.getVisibleBaseUrl())) {
+            resultingPageUrl =
+                    "/"
+                            + StringUtils.stripStart(
+                                    StringUtils.replace(resultingPageUrl, driverRequest.getVisibleBaseUrl(), ""), "/");
+        }
+        resultingPageUrl = ResourceUtils.getHttpUrlWithQueryString(resultingPageUrl, driverRequest, false);
+
+        return UriUtils.createURI(ResourceUtils.getHttpUrlWithQueryString(resultingPageUrl, driverRequest, false));
+    }
+
+}

--- a/esigate-core/src/main/java/org/esigate/test/conn/IResponseHandler2.java
+++ b/esigate-core/src/main/java/org/esigate/test/conn/IResponseHandler2.java
@@ -1,0 +1,16 @@
+package org.esigate.test.conn;
+
+import org.apache.http.HttpClientConnection;
+import org.apache.http.conn.routing.HttpRoute;
+import org.apache.http.protocol.HttpContext;
+
+/**
+ * A response handler with support for receiving connection information.
+ * 
+ * Can be used to test Http route behavior.
+ * 
+ * @author Nicolas Richeton
+ */
+public interface IResponseHandler2 extends IResponseHandler {
+    public void connect(HttpClientConnection conn, HttpRoute route, int connectTimeout, HttpContext context);
+}

--- a/esigate-core/src/main/java/org/esigate/test/conn/MockConnectionManager.java
+++ b/esigate-core/src/main/java/org/esigate/test/conn/MockConnectionManager.java
@@ -132,12 +132,12 @@ public class MockConnectionManager implements HttpClientConnectionManager {
 
     @Override
     public ConnectionRequest requestConnection(HttpRoute route, Object state) {
-        return connectionRequest;
+        return this.connectionRequest;
     }
 
     @Override
     public void releaseConnection(HttpClientConnection conn, Object newState, long validDuration, TimeUnit timeUnit) {
-        open.set(false);
+        this.open.set(false);
     }
 
     @Override
@@ -191,12 +191,14 @@ public class MockConnectionManager implements HttpClientConnectionManager {
     }
 
     public final boolean isOpen() {
-        return open.get();
+        return this.open.get();
     }
 
     @Override
     public void connect(HttpClientConnection conn, HttpRoute route, int connectTimeout, HttpContext context) {
-        // Nothing to do
+        if (this.responseHandler instanceof IResponseHandler2) {
+            ((IResponseHandler2) this.responseHandler).connect(conn, route, connectTimeout, context);
+        }
     }
 
     @Override

--- a/esigate-core/src/test/java/org/esigate/DriverTest.java
+++ b/esigate-core/src/test/java/org/esigate/DriverTest.java
@@ -1129,7 +1129,8 @@ public class DriverTest extends TestCase {
 
                 case 2:
                     // ESI fragment issuing redirect.
-                    Assert.assertEquals("http://externalhost:8180/account/my-bookings", request.getRequestLine().getUri());
+                    Assert.assertEquals("http://externalhost:8180/account/my-bookings", request.getRequestLine()
+                            .getUri());
 
                     response =
                             new BasicHttpResponse(new ProtocolVersion("HTTP", 1, 1), HttpStatus.SC_MOVED_PERMANENTLY,
@@ -1167,8 +1168,7 @@ public class DriverTest extends TestCase {
         // Ensure correct result.
         Assert.assertEquals("Entity content should be OK", "OK", EntityUtils.toString(response.getEntity()));
     }
-    
-    
+
     /**
      * This test ensure that redirects encountered while fetching fragments, generates new requests to the provider with
      * its internal uri, and not with the external uri as returned by the provider.

--- a/esigate-core/src/test/java/org/esigate/DriverTest.java
+++ b/esigate-core/src/test/java/org/esigate/DriverTest.java
@@ -25,6 +25,7 @@ import java.util.zip.GZIPOutputStream;
 import junit.framework.Assert;
 import junit.framework.TestCase;
 
+import org.apache.http.HttpClientConnection;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
@@ -32,6 +33,7 @@ import org.apache.http.HttpStatus;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.conn.routing.HttpRoute;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.InputStreamEntity;
@@ -39,6 +41,7 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.cookie.BasicClientCookie;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.protocol.HttpContext;
 import org.apache.http.util.EntityUtils;
 import org.esigate.esi.EsiRenderer;
 import org.esigate.events.Event;
@@ -55,6 +58,7 @@ import org.esigate.tags.BlockRenderer;
 import org.esigate.tags.TemplateRenderer;
 import org.esigate.test.TestUtils;
 import org.esigate.test.conn.IResponseHandler;
+import org.esigate.test.conn.IResponseHandler2;
 import org.esigate.test.conn.MockConnectionManager;
 import org.esigate.test.http.HttpResponseBuilder;
 import org.esigate.util.UriUtils;
@@ -1001,8 +1005,9 @@ public class DriverTest extends TestCase {
                 FetchEvent fetchEvent = (FetchEvent) event;
                 // uri of the incoming request
                 assertEquals("http://foo.com/test", fetchEvent.getHttpRequest().getOriginal().getRequestLine().getUri());
+
                 // uri of the outgoing request
-                // FIXME
+                // FIXME This assertion is disabled see https://github.com/esigate/esigate/issues/23
                 // assertEquals("http://foo.com/test", fetchEvent.getHttpRequest().getRequestLine().getUri());
                 return false;
             }
@@ -1015,4 +1020,228 @@ public class DriverTest extends TestCase {
         driver.proxy("/test", incomingRequest);
     }
 
+    /**
+     * This test ensure that redirects encountered while fetching fragments, generates new requests to the provider with
+     * its internal uri, and not with the external uri as returned by the provider.
+     * 
+     * Without visible url configured in provider
+     * 
+     * @see https://github.com/esigate/esigate/issues/169 Redirect handling for fragments is using the public host
+     *      instead of the configured provider
+     */
+    public void testRedirectFragmentWithExternalHost() throws Exception {
+        Properties properties = new Properties();
+        properties.put(Parameters.REMOTE_URL_BASE.getName(), "http://localhost");
+        properties.put(Parameters.PRESERVE_HOST, "true");
+
+        mockConnectionManager = new MockConnectionManager();
+        mockConnectionManager.setResponseHandler(new IResponseHandler2() {
+
+            int nb = 0; // Count requests
+
+            @Override
+            public HttpResponse execute(HttpRequest request) throws IOException {
+                nb++;
+
+                switch (nb) {
+                case 1:
+                    // The main page with ESI instructions
+                    Assert.assertEquals("/account/bookings", request.getRequestLine().getUri());
+
+                    BasicHttpResponse response =
+                            new BasicHttpResponse(new ProtocolVersion("HTTP", 1, 1), HttpStatus.SC_OK,
+                                    "<esi:include src=\"$(PROVIDER{tested})/account/my-bookings\"></esi:include>");
+                    response.addHeader("Content-type", "text/html");
+                    return response;
+
+                case 2:
+                    // ESI fragment issuing redirect.
+                    response =
+                            new BasicHttpResponse(new ProtocolVersion("HTTP", 1, 1), HttpStatus.SC_MOVED_PERMANENTLY,
+                                    "Found");
+                    response.addHeader("Location", "http://externalhost:8180/account/my-bookings/");
+                    return response;
+
+                case 3:
+                    // Final result
+                    Assert.assertEquals("/account/my-bookings/", request.getRequestLine().getUri());
+                    response = new BasicHttpResponse(new ProtocolVersion("HTTP", 1, 1), HttpStatus.SC_OK, "OK");
+                    return response;
+
+                }
+                Assert.fail("It should not take more than 3 requests");
+                return null;
+            }
+
+            @Override
+            public void connect(HttpClientConnection conn, HttpRoute route, int connectTimeout, HttpContext context) {
+                // All connections should be made to provider (http://localhost)
+                Assert.assertEquals("Requests must go to the provider host", "localhost", route.getTargetHost()
+                        .getHostName());
+                Assert.assertEquals("Requests must use the provider port", 80, route.getTargetHost().getPort());
+            }
+        });
+
+        Driver driver = createMockDriver(properties, mockConnectionManager);
+
+        // Request
+        IncomingRequest incomingRequest =
+                TestUtils.createIncomingRequest("http://externalhost:8180/account/bookings").build();
+
+        CloseableHttpResponse response = driver.proxy("/account/bookings", incomingRequest);
+
+        // Ensure correct result.
+        Assert.assertEquals("Entity content should be OK", "OK", EntityUtils.toString(response.getEntity()));
+    }
+
+    /**
+     * This test ensure that redirects encountered while fetching fragments, generates new requests to the provider with
+     * its internal uri, and not with the external uri as returned by the provider.
+     * 
+     * With visible url configured in provider
+     * 
+     * @see https://github.com/esigate/esigate/issues/169 Redirect handling for fragments is using the public host
+     *      instead of the configured provider
+     */
+    public void testRedirectFragmentWithExternalHostAndVisibleUrl() throws Exception {
+        Properties properties = new Properties();
+        properties.put(Parameters.REMOTE_URL_BASE.getName(), "http://localhost");
+        properties.put(Parameters.PRESERVE_HOST, "true");
+        properties.put(Parameters.VISIBLE_URL_BASE, "http://externalhost");
+
+        mockConnectionManager = new MockConnectionManager();
+        mockConnectionManager.setResponseHandler(new IResponseHandler2() {
+
+            int nb = 0; // Count requests
+
+            @Override
+            public HttpResponse execute(HttpRequest request) throws IOException {
+                nb++;
+
+                switch (nb) {
+                case 1:
+                    // The main page with ESI instructions
+                    BasicHttpResponse response =
+                            new BasicHttpResponse(new ProtocolVersion("HTTP", 1, 1), HttpStatus.SC_OK,
+                                    "<esi:include src=\"$(PROVIDER{tested})/account/my-bookings\"></esi:include>");
+                    response.addHeader("Content-type", "text/html");
+                    return response;
+
+                case 2:
+                    // ESI fragment issuing redirect.
+                    Assert.assertEquals("http://externalhost:8180/account/my-bookings", request.getRequestLine().getUri());
+
+                    response =
+                            new BasicHttpResponse(new ProtocolVersion("HTTP", 1, 1), HttpStatus.SC_MOVED_PERMANENTLY,
+                                    "Found");
+                    response.addHeader("Location", "http://externalhost:8180/account/my-bookings/");
+                    return response;
+
+                case 3:
+                    // Final result
+                    response = new BasicHttpResponse(new ProtocolVersion("HTTP", 1, 1), HttpStatus.SC_OK, "OK");
+                    return response;
+
+                }
+                Assert.fail("It should not take more than 3 requests");
+                return null;
+            }
+
+            @Override
+            public void connect(HttpClientConnection conn, HttpRoute route, int connectTimeout, HttpContext context) {
+                // All connections should be made to provider (http://localhost)
+                Assert.assertEquals("Requests must go to the provider host", "localhost", route.getTargetHost()
+                        .getHostName());
+                Assert.assertEquals("Requests must use the provider port", 80, route.getTargetHost().getPort());
+            }
+        });
+
+        Driver driver = createMockDriver(properties, mockConnectionManager);
+
+        // Request
+        IncomingRequest incomingRequest =
+                TestUtils.createIncomingRequest("http://externalhost:8180/account/my-bookings").build();
+
+        CloseableHttpResponse response = driver.proxy("/account/my-bookings", incomingRequest);
+
+        // Ensure correct result.
+        Assert.assertEquals("Entity content should be OK", "OK", EntityUtils.toString(response.getEntity()));
+    }
+    
+    
+    /**
+     * This test ensure that redirects encountered while fetching fragments, generates new requests to the provider with
+     * its internal uri, and not with the external uri as returned by the provider.
+     * 
+     * Test with base url context in uri
+     * 
+     * @see https://github.com/esigate/esigate/issues/169 Redirect handling for fragments is using the public host
+     *      instead of the configured provider
+     */
+    public void testRedirectFragmentWithExternalHostWithContext() throws Exception {
+        Properties properties = new Properties();
+        properties.put(Parameters.REMOTE_URL_BASE.getName(), "http://localhost/test");
+        properties.put(Parameters.PRESERVE_HOST, "true");
+
+        mockConnectionManager = new MockConnectionManager();
+        mockConnectionManager.setResponseHandler(new IResponseHandler2() {
+
+            int nb = 0; // Count requests
+
+            @Override
+            public HttpResponse execute(HttpRequest request) throws IOException {
+                nb++;
+
+                switch (nb) {
+                case 1:
+                    // The main page with ESI instructions
+                    Assert.assertEquals("/test/account/bookings", request.getRequestLine().getUri());
+
+                    BasicHttpResponse response =
+                            new BasicHttpResponse(new ProtocolVersion("HTTP", 1, 1), HttpStatus.SC_OK,
+                                    "<esi:include src=\"$(PROVIDER{tested})/account/my-bookings\"></esi:include>");
+                    response.addHeader("Content-type", "text/html");
+                    return response;
+
+                case 2:
+                    // ESI fragment issuing redirect.
+                    Assert.assertEquals("/test/account/my-bookings", request.getRequestLine().getUri());
+
+                    response =
+                            new BasicHttpResponse(new ProtocolVersion("HTTP", 1, 1), HttpStatus.SC_MOVED_PERMANENTLY,
+                                    "Found");
+                    response.addHeader("Location", "http://externalhost:8180/test/account/my-bookings/");
+                    return response;
+
+                case 3:
+                    // Final result
+                    Assert.assertEquals("/test/account/my-bookings/", request.getRequestLine().getUri());
+                    response = new BasicHttpResponse(new ProtocolVersion("HTTP", 1, 1), HttpStatus.SC_OK, "OK");
+                    return response;
+
+                }
+                Assert.fail("It should not take more than 3 requests");
+                return null;
+            }
+
+            @Override
+            public void connect(HttpClientConnection conn, HttpRoute route, int connectTimeout, HttpContext context) {
+                // All connections should be made to provider (http://localhost)
+                Assert.assertEquals("Requests must go to the provider host", "localhost", route.getTargetHost()
+                        .getHostName());
+                Assert.assertEquals("Requests must use the provider port", 80, route.getTargetHost().getPort());
+            }
+        });
+
+        Driver driver = createMockDriver(properties, mockConnectionManager);
+
+        // Request
+        IncomingRequest incomingRequest =
+                TestUtils.createIncomingRequest("http://externalhost:8180/account/bookings").build();
+
+        CloseableHttpResponse response = driver.proxy("/account/bookings", incomingRequest);
+
+        // Ensure correct result.
+        Assert.assertEquals("Entity content should be OK", "OK", EntityUtils.toString(response.getEntity()));
+    }
 }


### PR DESCRIPTION
…instead of the configured provider #169

https://github.com/esigate/esigate/issues/169
Add new testing capability for HttpRoute
Fix redirect handling for fragments