### PR TITLE
Update cobertura plugin- conflict with xml parser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,7 @@
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>cobertura-maven-plugin</artifactId>
-					<version>2.6</version>
+					<version>2.7</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
cobertura plugin uses an old xml api, causing issues with transform API