### PR TITLE
Update Jetty

### DIFF
--- a/esigate-core/pom.xml
+++ b/esigate-core/pom.xml
@@ -86,13 +86,13 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-util</artifactId>
-			<version>9.3.24.v20180605</version>
+			<version>9.4.12.v20180830</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>
-			<version>9.3.24.v20180605</version>
+			<version>9.4.12.v20180830</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.sonatype.oss</groupId>
 		<artifactId>oss-parent</artifactId>
-		<version>7</version>
+		<version>9</version>
 	</parent>
 	<prerequisites>
 		<maven>3.0</maven>


### PR DESCRIPTION
This is to fix a security warning from GitHub. 
In core, Jetty is only used for testing