### PR TITLE
Update Jetty

### DIFF
--- a/esigate-server/pom.xml
+++ b/esigate-server/pom.xml
@@ -134,7 +134,7 @@
 		</dependencies>
 	</dependencyManagement>
 	<properties>
-		<jetty.version>9.3.24.v20180605</jetty.version>
+		<jetty.version>9.4.12.v20180830</jetty.version>
 	</properties>
 	<reporting>
 		<plugins>

--- a/esigate-server/src/main/java/org/esigate/server/EsigateServer.java
+++ b/esigate-server/src/main/java/org/esigate/server/EsigateServer.java
@@ -275,7 +275,7 @@ public final class EsigateServer {
             context.setServer(srv);
             context.setTempDirectory(workDir);
             if (StringUtils.isNoneEmpty(sessionCookieName)) {
-                context.getSessionHandler().getSessionManager().getSessionCookieConfig().setName(sessionCookieName);
+                context.getSessionHandler().getSessionCookieConfig().setName(sessionCookieName);
             }
             // Add extra classpath (allows to add extensions).
             if (EsigateServer.extraClasspath != null) {


### PR DESCRIPTION
Update Jetty to fix a security warning from GitHub. 

In server, esigate runs on jetty. 