### PR TITLE
Remove stacktrace in the logs for NoHttpResponseException

### DIFF
--- a/esigate-core/src/main/java/org/esigate/HttpErrorPage.java
+++ b/esigate-core/src/main/java/org/esigate/HttpErrorPage.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -25,6 +25,7 @@ import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
 import org.apache.http.HttpVersion;
+import org.apache.http.NoHttpResponseException;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.conn.ConnectTimeoutException;
@@ -151,6 +152,8 @@ public class HttpErrorPage extends Exception {
             return generateHttpResponse(HttpStatus.SC_GATEWAY_TIMEOUT, "Socket timeout");
         } else if (exception instanceof SocketException) {
             return generateHttpResponse(HttpStatus.SC_BAD_GATEWAY, "Socket Exception");
+        } else if (exception instanceof NoHttpResponseException) {
+            return generateHttpResponse(HttpStatus.SC_BAD_GATEWAY, "The target server failed to respond");
         } else if (exception instanceof ClientProtocolException) {
             String message = exception.getMessage();
             if (message == null && exception.getCause() != null) {

--- a/esigate-core/src/test/java/org/esigate/HttpErrorPageTest.java
+++ b/esigate-core/src/test/java/org/esigate/HttpErrorPageTest.java
@@ -1,0 +1,19 @@
+package org.esigate;
+
+import junit.framework.TestCase;
+import org.apache.http.HttpStatus;
+import org.apache.http.NoHttpResponseException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+
+public class HttpErrorPageTest extends TestCase {
+    /**
+     * Make sure that {@link NoHttpResponseException} is handled with a specific error message rather than triggering
+     * the default exception handling that would pollute the logs with a stack trace.
+     */
+    public void testNoHttpResponseException() {
+        CloseableHttpResponse response =
+                HttpErrorPage.generateHttpResponse(new NoHttpResponseException("Something bad happened"));
+        assertEquals(HttpStatus.SC_BAD_GATEWAY, response.getStatusLine().getStatusCode());
+        assertEquals("The target server failed to respond", response.getStatusLine().getReasonPhrase());
+    }
+}


### PR DESCRIPTION
Remove stacktrace in the logs for NoHttpResponseException (was visible in the build logs)
Handle with a specific error message and BAD GATEWAY http status