### PR TITLE
[responseCode] Allows forced response code in a esi:except tag

### DIFF
--- a/esigate-core/src/main/java/org/esigate/esi/TryElement.java
+++ b/esigate-core/src/main/java/org/esigate/esi/TryElement.java
@@ -31,22 +31,30 @@ class TryElement extends BaseElement {
 
     };
     private boolean write = false;
-    private boolean hasErrors;
     private boolean exceptProcessed;
     private int errorCode;
+    private Exception error;
 
     TryElement() {
     }
 
     @Override
     protected boolean parseTag(Tag tag, ParserContext ctx) {
-        this.hasErrors = false;
+        this.error = null;
         this.errorCode = 0;
         return true;
     }
 
     public boolean hasErrors() {
-        return hasErrors;
+        return this.error != null;
+    }
+
+    public boolean hasHttpError() {
+        return this.hasErrors() && this.error instanceof HttpErrorPage;
+    }
+
+    public HttpErrorPage getHttpError() {
+        return (HttpErrorPage) this.error;
     }
 
     public int getErrorCode() {
@@ -70,9 +78,9 @@ class TryElement extends BaseElement {
 
     @Override
     public boolean onError(Exception e, ParserContext ctx) {
-        hasErrors = true;
-        if (e instanceof HttpErrorPage) {
-            errorCode = ((HttpErrorPage) e).getHttpResponse().getStatusLine().getStatusCode();
+        this.error = e;
+        if (this.hasHttpError()) {
+            errorCode = this.getHttpError().getHttpResponse().getStatusLine().getStatusCode();
         }
         return true;
     }

--- a/esigate-core/src/test/java/org/esigate/esi/TryElementTest.java
+++ b/esigate-core/src/test/java/org/esigate/esi/TryElementTest.java
@@ -17,6 +17,7 @@ package org.esigate.esi;
 import java.io.IOException;
 
 import org.esigate.HttpErrorPage;
+import org.junit.Assert;
 
 public class TryElementTest extends AbstractElementTest {
 
@@ -95,26 +96,57 @@ public class TryElementTest extends AbstractElementTest {
         assertEquals("begin inside except end", result);
     }
 
-    public void testExcept2() throws IOException, HttpErrorPage {
-        String page =
-                "begin <esi:try>" + "<esi:attempt> " + "<esi:include src='http://www.foo.com/test' /> abc "
-                        + "<esi:include src=\"http://www.foo2.com/test\" /> cba" + "</esi:attempt>"
-                        + "<esi:except>inside except</esi:except>" + "</esi:try> end";
-        String result = render(page);
-        assertEquals("begin inside except end", result);
-    }
+	public void testExcept2() throws IOException, HttpErrorPage {
+		String page =
+				"begin <esi:try>" + "<esi:attempt> " + "<esi:include src='http://www.foo.com/test' /> abc "
+						+ "<esi:include src=\"http://www.foo2.com/test\" /> cba" + "</esi:attempt>"
+						+ "<esi:except>inside except</esi:except>" + "</esi:try> end";
+		String result = render(page);
+		assertEquals("begin inside except end", result);
+	}
 
-    public void testMultipleExcept() throws IOException, HttpErrorPage {
-        String page =
-                "begin <esi:try>" + "<esi:attempt> "
-                        + "<esi:attempt>abc <esi:include src='http://www.foo2.com/test' /> cba</esi:attempt>"
-                        + "</esi:attempt>" + "<esi:except code='500'>inside incorrect except</esi:except>"
-                        + "<esi:except code='404'>inside correct except</esi:except>"
-                        + "<esi:except code='412'>inside incorrect except</esi:except>"
-                        + "<esi:except>inside default except</esi:except>" + "</esi:try> end";
-        String result = render(page);
-        assertEquals("begin inside correct except end", result);
-    }
+	public void testExceptWithForcedResponseCode() throws IOException {
+		String page =
+				"begin <esi:try>"
+						+ "<esi:attempt>abc <esi:include src=\"http://www.foo2.com/test\" /> cba</esi:attempt>"
+						+ "<esi:except responseCode=\"503\">inside except</esi:except>" + "</esi:try> end";
+
+		try {
+			render(page);
+			Assert.fail("Must generate an error page.");
+		} catch (HttpErrorPage error) {
+			Assert.assertEquals(503, error.getHttpResponse().getStatusLine().getStatusCode());
+		}
+	}
+
+	public void testMultipleExcept() throws IOException, HttpErrorPage {
+		String page =
+				"begin <esi:try>" + "<esi:attempt> "
+						+ "<esi:attempt>abc <esi:include src='http://www.foo2.com/test' /> cba</esi:attempt>"
+						+ "</esi:attempt>" + "<esi:except code='500'>inside incorrect except</esi:except>"
+						+ "<esi:except code='404'>inside correct except</esi:except>"
+						+ "<esi:except code='412'>inside incorrect except</esi:except>"
+						+ "<esi:except>inside default except</esi:except>" + "</esi:try> end";
+		String result = render(page);
+		assertEquals("begin inside correct except end", result);
+	}
+
+	public void testMultipleExceptWithForcedResponseCode() throws IOException, HttpErrorPage {
+		String page =
+				"begin <esi:try>" + "<esi:attempt> "
+						+ "<esi:attempt>abc <esi:include src='http://www.foo2.com/test' /> cba</esi:attempt>"
+						+ "</esi:attempt>" + "<esi:except code='500'>inside incorrect except</esi:except>"
+						+ "<esi:except code='404' responseCode='503'>inside correct except</esi:except>"
+						+ "<esi:except code='412'>inside incorrect except</esi:except>"
+						+ "<esi:except>inside default except</esi:except>" + "</esi:try> end";
+
+		try {
+			render(page);
+			Assert.fail("Must generate an error page.");
+		} catch (HttpErrorPage error) {
+			Assert.assertEquals(503, error.getHttpResponse().getStatusLine().getStatusCode());
+		}
+	}
 
     public void testDefaultExcept() throws IOException, HttpErrorPage {
         String page =

--- a/src/site/xdoc/reference.xml
+++ b/src/site/xdoc/reference.xml
@@ -637,7 +637,7 @@ someUrl=/cms/article123
 			<source>
 &lt;esi:try&gt;
    &lt;esi:attempt&gt; ... &lt;/esi:attempt&gt;
-   &lt;esi:except code="500"&gt; ... &lt;/esi:except&gt;
+   &lt;esi:except code="500" responseCode="503"&gt; ... &lt;/esi:except&gt;
 &lt;/esi:try&gt;</source>
 		</subsection>
 		<subsection name="&lt;esi:choose&gt; &lt;esi:when&gt; &lt;esi:otherwise&gt;">
@@ -888,6 +888,16 @@ someUrl=/cms/article123
 			<td>Yes</td>
 			<td>Yes</td>
 			<td>Yes</td>
+			<td>&nbsp;</td>
+			</tr>
+			<tr>
+			<td></td>
+			<td>responseCode</td>
+			<td>Http return code that will be returned by this except block</td>
+			<td></td>
+			<td>&nbsp;</td>
+			<td>Yes</td>
+			<td>&nbsp;</td>
 			<td>&nbsp;</td>
 			</tr>
 			<tr>


### PR DESCRIPTION
This change allows ESIGate to return a custom response code when using try/except tags (instead of a plain old 200)
