### PR TITLE
[responseCode] Added OnErrorResponseCodeReplacer extension

### DIFF
--- a/esigate-core/src/main/java/org/esigate/Parameters.java
+++ b/esigate-core/src/main/java/org/esigate/Parameters.java
@@ -22,7 +22,9 @@ import org.esigate.extension.ConfigReloadOnChange;
 import org.esigate.extension.Esi;
 import org.esigate.extension.FetchLogging;
 import org.esigate.extension.FragmentLogging;
+import org.esigate.extension.OnErrorResponseCodeReplacer;
 import org.esigate.extension.ResourceFixup;
+import org.esigate.extension.XCorrelationId;
 import org.esigate.extension.XPoweredBy;
 import org.esigate.extension.surrogate.Surrogate;
 import org.esigate.util.Parameter;
@@ -79,7 +81,8 @@ public final class Parameters {
     public static final Parameter<Collection<String>> EXTENSIONS = new ParameterCollection("extensions",
             FragmentLogging.class.getName(), FetchLogging.class.getName(),
             RemoteUserAuthenticationHandler.class.getName(), Esi.class.getName(), ResourceFixup.class.getName(),
-            XPoweredBy.class.getName(), Surrogate.class.getName(), ConfigReloadOnChange.class.getName());
+            XPoweredBy.class.getName(), Surrogate.class.getName(), ConfigReloadOnChange.class.getName(),
+			XCorrelationId.class.getName(), OnErrorResponseCodeReplacer.class.getName());
     // Cache settings
     public static final Parameter<Boolean> USE_CACHE = new ParameterBoolean("useCache", true);
     public static final Parameter<Integer> MAX_CACHE_ENTRIES = new ParameterInteger("maxCacheEntries", 1000);

--- a/esigate-core/src/main/java/org/esigate/extension/OnErrorResponseCodeReplacer.java
+++ b/esigate-core/src/main/java/org/esigate/extension/OnErrorResponseCodeReplacer.java
@@ -1,0 +1,79 @@
+/* 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.esigate.extension;
+
+import java.util.Properties;
+
+import org.apache.http.HttpStatus;
+import org.esigate.Driver;
+import org.esigate.events.Event;
+import org.esigate.events.EventDefinition;
+import org.esigate.events.EventManager;
+import org.esigate.events.IEventListener;
+import org.esigate.events.impl.FragmentEvent;
+import org.esigate.util.Parameter;
+import org.esigate.util.ParameterInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This extension replaces response code when an error was returned during process
+ * <p>
+ * Be sure to put this extension last
+ * 
+ * <p>
+ * Variables:
+ * <ul>
+ * <li>onerror_response_code: integer (response code used as replacement)</li>
+ * </ul>
+ * </p>
+ * 
+ * @author VeekeeFr
+ * 
+ */
+public class OnErrorResponseCodeReplacer implements Extension, IEventListener {
+    private static final Logger LOG = LoggerFactory.getLogger(OnErrorResponseCodeReplacer.class);
+    public static final Parameter<Integer> ON_ERROR_RESPONSE_CODE = new ParameterInteger("onerror_response_code", 0);
+    private int newResponseCode;
+
+    @Override
+    public void init(Driver pDriver, Properties properties) {
+        this.newResponseCode = ON_ERROR_RESPONSE_CODE.getValue(properties);
+        if (newResponseCode == 0) {
+            LOG.warn(
+                    "No onerror_response_code value could be retrieved for instance '{}'... Extension will be disabled!",
+                    pDriver.getConfiguration().getInstanceName());
+            return;
+        }
+
+		pDriver.getEventManager().register(EventManager.EVENT_FRAGMENT_POST, this);
+    }
+
+    @Override
+    public boolean event(EventDefinition id, Event event) {
+        FragmentEvent e = (FragmentEvent) event;
+
+        int statusCode = e.getHttpResponse().getStatusLine().getStatusCode();
+
+        if (statusCode >= HttpStatus.SC_BAD_REQUEST) {
+            e.getHttpResponse().setStatusCode(newResponseCode);
+        }
+
+        // Continue processing
+        return true;
+    }
+
+}


### PR DESCRIPTION
This change adds an ESIGate to allow custom response codes when an error was detected in a previous step.


Note to Nicolas : The extension method was indead more simple to implement (than using an esi tag parameter). Anyway, I don't know whether its a good idea or not to include it in the main esigate repository, so I'll fully understand if you choose not to :)